### PR TITLE
Gsub fix

### DIFF
--- a/app/views/shared/_album_card.html.erb
+++ b/app/views/shared/_album_card.html.erb
@@ -2,7 +2,7 @@
   <div class="card-img" id="album-img" style="background-image:url(<%= album[:cover_image_url] %>);">
 		<div class="overlay">
 			<div class="overlay-content">
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#<%= album[:title].gsub(/[!@%&0-9,\(\)\s+]/, "") %>">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#_<%= album[:id] %>">
           View Album
         </button>
 			</div>

--- a/app/views/shared/_search_modal.html.erb
+++ b/app/views/shared/_search_modal.html.erb
@@ -1,6 +1,6 @@
 
 <!-- Modal -->
-<div class="modal fade" id="<%= album[:title].gsub(/[!@%&0-9\'\,\(\)\s+]/, "") %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="_<%= album[:id] %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/shared/_stack_album_card.html.erb
+++ b/app/views/shared/_stack_album_card.html.erb
@@ -2,7 +2,7 @@
   <div class="card-img" id="album-img" style="background-image:url(<%= stack_album.album[:cover_image_url] %>);">
 		<div class="overlay">
 			<div class="overlay-content">
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#<%= stack_album.album[:title].gsub(/[!@%&0-9,\(\)\s+]/, "") %>">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#_<%= stack_album.album[:spotify_id] %>">
           View Album
         </button>
 			</div>

--- a/app/views/shared/_stack_modal.html.erb
+++ b/app/views/shared/_stack_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="<%= stack_album.album[:title].gsub(/[!@%&0-9\'\,\(\)\s+]/, "") %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="_<%= stack_album.album[:spotify_id] %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -39,7 +39,7 @@
         </div>
       </div>
       <div class="modal-footer mx-auto">
-        <%= link_to "Delete", stack_album_path(stack_album_url), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger" %>
+        <%= link_to "Delete", stack_album_path(stack_album), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger" %>
         <a href="" data-bs-dismiss="modal" class="btn btn-outline-secondary">Back</a>
       </div>
     </div>

--- a/app/views/shared/_track_card.html.erb
+++ b/app/views/shared/_track_card.html.erb
@@ -3,7 +3,7 @@
   <div class="card-product-infos">
     <h2><%= track[:title] %></h2>
     <p><%= track[:artist] %></p>
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#<%= track[:title].gsub(/[!@%&0-9,\(\)\s+]/, "") %>">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#_<%= track[:spotify_id] %>">
           Add Track
     </button>
   </div>

--- a/app/views/shared/_track_modal.html.erb
+++ b/app/views/shared/_track_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="<%= track[:title].gsub(/[!@%&0-9,\(\)\s+]/, "") %>" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="_<%= track[:spotify_id] %>" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/shared/_track_modal.html.erb
+++ b/app/views/shared/_track_modal.html.erb
@@ -13,14 +13,20 @@
       <div class="modal-footer">
 
 
+        <!--> THIS IF ELSE IS A TEMPORARY FIX <-->
+        <% if @setlists.nil? %>
+          <%= link_to "Create a new set", new_setlist_path %>
+          <a href="" data-bs-dismiss="modal" style="color: red;">Back</a>
 
-      <%= link_to "Add to Set",
-        setlist_set_tracks_path(setlist_id: Setlist.last.id, track_id: track[:spotify_id]),
-          method: :create,
-          class: "btn btn-outline-secondary",
-          "data-bs-dismiss": "modal"%>
-        <a href="" data-bs-dismiss="modal" style="color: red;">Back</a>
-        </div>
+        <% else %>
+          <%= link_to "Add to Set",
+            setlist_set_tracks_path(setlist_id: Setlist.last.id, track_id: track[:spotify_id]),
+              method: :create,
+              class: "btn btn-outline-secondary",
+              "data-bs-dismiss": "modal"%>
+            <a href="" data-bs-dismiss="modal" style="color: red;">Back</a>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
when you click View album, instead of doing the gsub dance - it takes the spotify id. This wasn't previously working because you can't have css selectors starting with numbers. Figured out that we could add an underscore to the front of the string and it would accept that. Now we can add albums with symbols and random chars in without having the gsub probs. win!

Also corrected the delete album from stack, which was taking the path as an arg instead of the stack_album itself.